### PR TITLE
KVP-25 Adding docs for the Registry (for Avalia)

### DIFF
--- a/docs/technical/_category_.json
+++ b/docs/technical/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Teknisk dokumentasjon",
+  "position": 6,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/technical/registry/_category_.json
+++ b/docs/technical/registry/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Registeret",
+  "position": 1,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/technical/registry/basics.md
+++ b/docs/technical/registry/basics.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+---
+
+# Om registeret
+
+Registeret inneholder kjerneiformasjon for tjenestene som er tilknyttet Kvipp og delvis DigiQuip. Det er et passivt register og vil bare i liten grad utføre operasjoner med unntak av enkle oppgaver som å generere PDFer og bilder, samt sende ut epostmeldinger. Det er tilgjenglig for test og produksjon på følgende adresser:
+* [For testing: https://test-registry.kvipp.io](https://test-registry.kvipp.io) ( [Swagger dokumentasjon på /docs](https://test-registry.kvipp.io/docs))
+* [Live: https://registry.kvipp.io](https://registry.kvipp.io) ( [Swagger dokumentasjon på /docs](https://registry.kvipp.io/docs))
+
+## Autentisering
+
+Det benyttes nå "Basic Authentication" for endepunktene. Brukernavn og passord gis ut til parter med relevant behov. Ta kontakt med oss på support@digiquip.no.
+
+## Krav om datakvalitet
+
+Prinsippet for registeret er å tillate at informasjon enkelt kan legges inn men at det kontinuerlig forbedres. På samme måte som du vil håndtere data for slektsforskning, vil du raskt kunne legge inn grunndata og koblinger, os så vil dine og andres prosesser koble til og forbedre disse dataene etterhvert. Det er derfor viktig at det benyttes eksterne idenfikatorer når du skal koble data fra dine systemer og til registeret. Dette er forklart nærmere i [Eksterne identifikatorer](identifiers.md)

--- a/docs/technical/registry/identifiers.md
+++ b/docs/technical/registry/identifiers.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+---
+
+# Eksterne identifikatorer
+
+Eksterne identifikatorer er en metode for å tillate andre systemer å lagre sin ID for et objekt, f.eks. en person, i registeret. Siden alle objekter i registeret allerede har en ID, vil dette kunne synes kontraproduktivt, men med tanke på at data og datakvalitet stadig forbedres i registeret, gir dette muligheten for å ha en konsistent kobling mot tidvis skiftende data.
+
+## Mot hva?
+
+Ekstern identifikatorer er "polymorfiske". Det betyr at de kan peke mot forskjellige andre kategorier av data. I vårt tilfelle kan dette være:
+
+* Menneske (Person)
+* Utstyrtype (Asset Type)
+* Utstyr (Asset)
+
+## Eksempel
+
+La oss si at du har et system som vi kaller i "xyz". I dette systemet har mennesket "Ola Normann" ID "xyz123". Ola Normann finnes også registert i Registeret, her med id "5574043f-4fc1-48d2-82a6-7dcf73418390". En oppføring i "Identifiers" vil dermed kunne bli:
+
+```
+{
+    "source": "xyz",
+    "identity": "xy123",
+    "foreign_id": "5574043f-4fc1-48d2-82a6-7dcf73418390",
+    "type": "person"
+}
+```
+
+Når dette er registret vil du kunne spørre om denne identiteten i registeret og få mennesket og alle relaterte data i en spørring, uten å forholde deg til hvilken ID mennesket har eller om det har foregått en sammenslåing eller oppdatering av data.
+
+## Eksempel 2: Finn eller opprett utstyr og koble en identifikator til den
+
+Om du har data for merke, modell og potensielt et versjonsnummer og et serienummer, kan du sende en POST mot endepunktet [https://registry.kvipp.io/assets/find](https://registry.kvipp.io/assets/find) med eks. følgende data som JSON:
+```
+{
+  "serial_number": "MAN000Q0E01000330 ",
+  "brand": " Manitou ",
+  "model": "280 TJ"
+}
+```
+Om denne finnes vil du få objektet tilbake, om ikke, og om du har satt parameteret `create` til `true`, vil både utstyrstypen og utstyret skapes og returneres til deg. Om den finnes bør du sjekke for en ekstern identifikator, om ikke kan du lage en med IDen du fikk tilbake fra kallet over, f.eks.:
+```
+{
+    "source": "system_x",
+    "identity": "ID8812313",
+    "foreign_id": "6dd19106-3708-4fea-becc-45ae3c001a4f",
+    "type": "asset"
+}
+``` 
+
+## Koble en DigiQuip QR-kode til et utstyr eller utstyrstype
+
+På QR-koden står det en syvsifret alfanumerisk kombinasjon (f.eks. "PYZEV1Q"). Om du ønsker å koble dette f.eks. til et utstyr med ID `22934840-6214-4b84-bfde-7b239c6d2e33`, vil identifikatoren du skal opprette (om den ikke finnes) være:
+```
+{
+    "source": "digiquip_qr",
+    "identity": "PYZEV1Q",
+    "foreign_id": "22934840-6214-4b84-bfde-7b239c6d2e33",
+    "type": "asset"
+}
+``` 
+
+**Sjekk evt. om IDen finnes først!**

--- a/docs/technical/registry/structure.md
+++ b/docs/technical/registry/structure.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 2
+---
+
+# Oppbygning
+
+Hovedhensikten med våre løsninger er å koble sammen menneske og arbeidsutstyr gjennom kompetanse og handlinger. I all hovedsak vil slike koblinger foregå gjennom at mennesker tilegner seg kompetanse og utfører handlinger, mens utstyr, som oftest gjennom merke/modell/kategorisering har påkrevd kompetanse eller handlinger. Et eksempel på en en slik kobling er dermed:
+
+***menneske*** < - > ***tilegnet kompetanse*** < - > ***kompetanse*** < - > ***påkrevd kompetanse*** < - > ***utstyrstype*** < - > ***utstyr***
+
+## De viktigste kategoriene
+
+**Menneske (Person/People)**
+Registerinformasjon om et enkelt individ, basert på fornavn, etternavn, fødselsdato og nasjonalitet.
+
+**Utstyrstyper (Asset Types)**
+Representerer i de aller fleste tilfeller en spesiell modell av et spesielt merke. Kan også gå videre ned på versjonsnivå.
+
+**Utstyr (Asset)**
+Dette er enkeltindivider av en utstyrstype, spesifisert med et serienummer (eller VIN-nummer).

--- a/i18n/en/docusaurus-plugin-content-docs/current/technical/_category_.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current/technical/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Technical documentation",
+  "position": 6,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/_category_.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "The Registry",
+  "position": 1,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/basics.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/basics.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+---
+
+# About the Registry
+
+The registry contains core information for the services connected to Kvipp and partially to DigiQuip. It is a passive registry and will only perform operations to a limited extent, with the exception of simple tasks such as generating PDFs and images, as well as sending out emails. It is available for testing and production at the following addresses:
+* [For testing: https://test-registry.kvipp.io](https://test-registry.kvipp.io) ( [Swagger documentation at /docs](https://test-registry.kvipp.io/docs))
+* [Live: https://registry.kvipp.io](https://registry.kvipp.io) ( [Swagger documentation at /docs](https://registry.kvipp.io/docs))
+
+## Authentication
+
+"Basic Authentication" is now used for the endpoints. Username and password are provided to parties with relevant needs. Please contact us at support@digiquip.no.
+
+## Data Quality Requirements
+
+The principle of the registry is to allow information to be easily entered but continuously improved. Just as you would handle data for genealogy, you can quickly input basic data and connections, and then your processes, as well as others, will connect to and improve these data over time. Therefore, it is important to use external identifiers when linking data from your systems to the registry. This is explained in more detail in [External Identifiers](identifiers.md).

--- a/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/identifiers.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/identifiers.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+---
+
+# External Identifiers
+
+External identifiers are a method that allows other systems to store their ID for an object, e.g., a person, in the registry. Since all objects in the registry already have an ID, this might seem counterproductive, but considering that data and data quality are continuously improving in the registry, this provides an opportunity to maintain a consistent link to occasionally changing data.
+
+## What can they refer to?
+
+External identifiers are "polymorphic." This means they can point to different categories of data. In our case, this can be:
+
+Person
+Asset Type
+Asset
+
+## Example
+
+Let’s say you have a system we call "xyz." In this system, the person "Ola Normann" has the ID "xyz123." Ola Normann is also registered in the Registry, with the ID "5574043f-4fc1-48d2-82a6-7dcf73418390." An entry in "Identifiers" could therefore be:
+
+```
+{
+    "source": "xyz",
+    "identity": "xyz123",
+    "foreign_id": "5574043f-4fc1-48d2-82a6-7dcf73418390",
+    "type": "person"
+}
+```
+
+Once this is registered, you can query this identity in the registry and retrieve the person and all related data in one query, without needing to track what ID the person has or whether there has been a merge or update of the data.
+
+## Example 2: Find or create an asset and link an identifier to it
+
+If you have data for the brand, model, and potentially a version number and a serial number, you can send a POST request to the endpoint https://registry.kvipp.io/assets/find with the following example data as JSON:
+
+```
+{
+  "serial_number": "MAN000Q0E01000330",
+  "brand": "Manitou",
+  "model": "280 TJ"
+}
+```
+
+If this asset exists, you will receive the object in return. If not, and if you have set the create parameter to true, both the asset type and the asset will be created and returned to you. If it exists, you should check for an external identifier; if not, you can create one with the ID you received from the previous call, e.g.:
+
+```
+{
+    "source": "system_x",
+    "identity": "ID8812313",
+    "foreign_id": "6dd19106-3708-4fea-becc-45ae3c001a4f",
+    "type": "asset"
+}
+```
+
+## Link a DigiQuip QR code to an asset or asset type
+
+On the QR code, there is a seven-character alphanumeric combination (e.g., "PYZEV1Q"). If you want to link this to an asset with ID 22934840-6214-4b84-bfde-7b239c6d2e33, the identifier you should create (if it doesn't already exist) would be:
+
+```
+{
+    "source": "digiquip_qr",
+    "identity": "PYZEV1Q",
+    "foreign_id": "22934840-6214-4b84-bfde-7b239c6d2e33",
+    "type": "asset"
+}
+```
+
+**Check first if the identifier already exists!**

--- a/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/structure.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/technical/registry/structure.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 2
+---
+
+Here is the English translation with markdown formatting preserved:
+
+# Structure
+
+The main purpose of our solutions is to connect people and assets / work equipment through skills and actions. In general, such connections will occur as people acquire skills and perform actions, while assets, usually categorized by brand/model/type, requires specific skills or actions. An example of such a connection is:
+
+***person*** < - > ***acquired skills*** < - > ***skills*** < - > ***required skills*** < - > ***asset type*** < - > ***asset***
+
+## The Key Categories
+
+**Person (Person/People)**
+Registry information about an individual, based on first name, last name, date of birth, and nationality.
+
+**Asset Type**
+In most cases, this represents a specific model of a particular brand. It can also go down to the version level.
+
+**Asset**
+These are individual instances of an asset type, specified with a serial number (or VIN number).


### PR DESCRIPTION
This pull request includes several updates to the technical documentation, focusing on the structure and content of the registry documentation. The most important changes include the addition of new category files, updates to the basics, structure, and identifiers documentation, and the translation of these updates into English.

### Documentation Updates:

* [`docs/technical/_category_.json`](diffhunk://#diff-10fd83624f5537b07cb9c059706d40eabcea7309d2edb00c972f3d943155f477R1-R7): Added a new category for technical documentation.
* [`docs/technical/registry/_category_.json`](diffhunk://#diff-c828cc0c64da0f57aed2d9426b8868bacceffed5683cd940c91b13c5c09c5281R1-R7): Added a new category for the registry section.
* [`docs/technical/registry/basics.md`](diffhunk://#diff-5bac5bc8d86e480f3aad047665e56a936192021ade8786d8349325bc68e2765fR1-R17): Added a new document explaining the registry basics, including its purpose, authentication, and data quality requirements.
* [`docs/technical/registry/identifiers.md`](diffhunk://#diff-065c3f4a7c4d0682e4745ed2ee0f514426a82f783321ffa509ff68118ec9aa69R1-R64): Added a new document detailing the use of external identifiers within the registry.
* [`docs/technical/registry/structure.md`](diffhunk://#diff-9ec710d31734b8ec41fa8bee33b6fc96344b52d7a8eb11dc5ccb99dd1a1507f8R1-R20): Added a new document outlining the structure of the registry, including key categories like people, asset types, and assets.

### English Translations:

* [`i18n/en/docusaurus-plugin-content-docs/current/technical/_category_.json`](diffhunk://#diff-6e073c57177b06725411db00d44ea855d067298359c8a49b9076b835cbf685f8R1-R7): Added a new category for technical documentation in English.
* [`i18n/en/docusaurus-plugin-content-docs/current/technical/registry/_category_.json`](diffhunk://#diff-cf7b01e44bb09b854e3f2b6c487d1d8d6ef1521430baa2b05e86a1e2f9475a1aR1-R7): Added a new category for the registry section in English.
* [`i18n/en/docusaurus-plugin-content-docs/current/technical/registry/basics.md`](diffhunk://#diff-216fb1d8ce4ecd6c4ea5373198fa2f47bd8e4f8d9d555ca5022218f1490a245cR1-R17): Added the English translation for the registry basics document.
* [`i18n/en/docusaurus-plugin-content-docs/current/technical/registry/identifiers.md`](diffhunk://#diff-075c6877d9e23020c4aea30287e62cb2a00780eb6e01684d4d85f697e92429f2R1-R68): Added the English translation for the external identifiers document.
* [`i18n/en/docusaurus-plugin-content-docs/current/technical/registry/structure.md`](diffhunk://#diff-af63b266e8a813c3c4d507348c436c348e9a4856b07c193ec1f7d0ad797b3873R1-R22): Added the English translation for the registry structure document.