### PR TITLE
Chore: Adding plausible

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
       }),
     ],
   ],
-
+  scripts: [{src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'digiquip.no'}],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({


### PR DESCRIPTION
This pull request includes a small change to the `docusaurus.config.js` file. The change adds a new script to the configuration for loading an external JavaScript file from Plausible.io.

* [`docusaurus.config.js`](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL68-R68): Added a script to load an external JavaScript file from Plausible.io with the `defer` attribute and set the `data-domain` to `digiquip.no`.