### PR TITLE
Adding the new status page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -194,7 +194,7 @@ const config = {
             items: [
               {
                 label: 'Services Status (Uptime)',
-                href: 'https://uptime.statuscake.com/?TestID=f9dgQKO3Az',
+                href: 'https://status.kvipp.io',
               },
             ],
           },


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and the configuration of the Docusaurus documentation site. The most important changes are:

Deployment Workflow Update:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L32-R32): Updated the GitHub Pages action from version 3 to version 4 to ensure compatibility and leverage the latest features.

Docusaurus Configuration Update:
* [`docusaurus.config.js`](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL197-R197): Updated the URL for the "Services Status (Uptime)" link to point to the new status page at `https://status.kvipp.io`.