### PR TITLE
Småfikser

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ const linkHtml =  ' <span> <svg width="13" height="12" viewBox="0 0 13 12" fill=
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'DigiQuip - Utstyrsspesifikk opplæring og kompetansedokumentasjon',
-  tagline: 'Våre løsninger legger til rette for utstyrsspesifikk opplæring på både eget og innleid utstyr, og gir oversikt over dokumentert og sertifisert kompetanse.',
+  tagline: 'DigiQuip er navet som enkelt kobler maskin- og utstyrsparken din med tilgjengelig dokumentasjon, kontrollrutiner, sikkerhetsopplæring og spesifikk maskin- og utstyrsopplæring.',
   favicon: 'img/dq.ico',
 
   // Set the production url of your site here

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -3,9 +3,9 @@
     "message": "The DigiQuip logo",
     "description": "The alt text of navbar logo"
   },
-  "item.label.Solutions": {
-    "message": "Solutions",
-    "description": "Navbar item with label Solutions"
+  "item.label.Products": {
+    "message": "Products",
+    "description": "Navbar item with label Products"
   },
   "item.label.Competence": {
     "message": "Competence",
@@ -23,9 +23,9 @@
     "message": "Pricing",
     "description": "Navbar item with label Pricing"
   },
-  "item.label.Login": {
-    "message": "Login",
-    "description": "Navbar item with label Login"
+  "item.label.Sign in": {
+    "message": "Sign in",
+    "description": "Navbar item with label Sign in"
   },
   "item.label.Scan QR": {
     "message": "Scan QR",

--- a/i18n/nb/docusaurus-theme-classic/navbar.json
+++ b/i18n/nb/docusaurus-theme-classic/navbar.json
@@ -3,9 +3,9 @@
     "message": "DigiQuip logoen",
     "description": "DigiQuip logo"
   },
-  "item.label.Solutions": {
+  "item.label.Products": {
     "message": "Produkter",
-    "description": "Navigering til løsninger"
+    "description": "Navigering til produkter"
   },
   "item.label.Competence": {
     "message": "Kvipp",
@@ -23,7 +23,7 @@
     "message": "Priser",
     "description": "Navigering til priser"
   },
-  "item.label.Login": {
+  "item.label.Sign in": {
     "message": "Logg inn",
     "description": "Navbar element med etikett Logg inn"
   },


### PR DESCRIPTION
- På .no: Fra "products" til produkter og "log in" til "logg inn"
- Endret slogan til det nyeste (digiquip er navet som....)